### PR TITLE
track node destroy

### DIFF
--- a/modality-ros-hook/Cargo.lock
+++ b/modality-ros-hook/Cargo.lock
@@ -79,73 +79,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
-name = "crossbeam"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
-dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "cstr"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +107,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "errno"
@@ -292,6 +231,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,15 +271,6 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "memoffset"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "minicbor"
@@ -442,16 +381,15 @@ version = "0.1.2"
 dependencies = [
  "arc-swap",
  "archery",
- "crossbeam",
  "cstr",
  "fxhash",
+ "itertools",
  "lazy_static",
  "modality-api",
  "modality-ingest-client",
  "redhook",
  "rpds",
  "tokio",
- "url",
  "widestring",
 ]
 
@@ -663,12 +601,6 @@ checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
  "windows-sys 0.42.0",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"

--- a/modality-ros-hook/Cargo.lock
+++ b/modality-ros-hook/Cargo.lock
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "modality-ros-hook"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "arc-swap",
  "archery",
@@ -452,7 +452,6 @@ dependencies = [
  "rpds",
  "tokio",
  "url",
- "uuid",
  "widestring",
 ]
 

--- a/modality-ros-hook/Cargo.toml
+++ b/modality-ros-hook/Cargo.toml
@@ -17,11 +17,10 @@ lazy_static = "1.4"
 rpds = "0.12"
 archery = "0.4"
 arc-swap = "1.6"
-crossbeam = "0.8"
 widestring = "1"
-url = "2.1"
 tokio = { version = "1", features = ["rt", "sync"] }
 fxhash = "0.2"
+itertools = "0.10"
 
 modality-api = "0.1"
 modality-ingest-client = "0.2"

--- a/modality-ros-hook/Cargo.toml
+++ b/modality-ros-hook/Cargo.toml
@@ -21,7 +21,6 @@ crossbeam = "0.8"
 widestring = "1"
 url = "2.1"
 tokio = { version = "1", features = ["rt", "sync"] }
-uuid = { version = "1", features = ["v5"] }
 fxhash = "0.2"
 
 modality-api = "0.1"

--- a/modality-ros-hook/src/hooks.rs
+++ b/modality-ros-hook/src/hooks.rs
@@ -6,7 +6,7 @@ use crate::{
 use arc_swap::ArcSwap;
 use archery::ArcK;
 use lazy_static::lazy_static;
-use modality_api::{AttrVal, Nanoseconds};
+use modality_api::{AttrVal, Nanoseconds, TimelineId};
 
 use std::{
     cell::RefCell,
@@ -19,23 +19,22 @@ thread_local! {
     /// thread (called by the DDS layer for the transport-level
     /// timestamp), we capture the time, add it to the message, and put
     /// it on SEND_CH for processing.
-    pub static LAST_CAPTURED_MESSAGE: RefCell<Option<CapturedMessage<'static>>>  = RefCell::new(None);
+    pub static LAST_CAPTURED_MESSAGE: RefCell<Option<CapturedMessage>> = RefCell::new(None);
 }
 
-// TODO destroy node/publisher/subscription is a thing... do we care to track those?
-
 lazy_static! {
-    static ref NODES: ArcSwap<rpds::List<NodeState, ArcK>> =
-        ArcSwap::from_pointee(rpds::List::<NodeState, ArcK>::new_with_ptr_kind());
+    static ref NODES: ArcSwap<rpds::HashTrieMap<NodePtr, NodeState, ArcK>> =
+        // TODO simpler?
+        ArcSwap::from_pointee(Default::default());
 
-    static ref PUBLISHERS: ArcSwap<rpds::List<PublisherState, ArcK>> =
-        ArcSwap::from_pointee(rpds::List::<PublisherState, ArcK>::new_with_ptr_kind());
+    static ref PUBLISHERS: ArcSwap<rpds::HashTrieMap<PublisherPtr, PublisherState, ArcK>> =
+        ArcSwap::from_pointee(Default::default());
 
-    static ref SUBSCRIPTIONS: ArcSwap<rpds::List<SubscriptionState, ArcK>> =
-        ArcSwap::from_pointee(rpds::List::<SubscriptionState, ArcK>::new_with_ptr_kind());
+    static ref SUBSCRIPTIONS: ArcSwap<rpds::HashTrieMap<SubscriptionPtr, SubscriptionState, ArcK>> =
+        ArcSwap::from_pointee(Default::default());
 
 
-    static ref SEND_CH: tokio::sync::mpsc::UnboundedSender<CapturedMessageWithTime<'static>> = {
+    static ref SEND_CH: tokio::sync::mpsc::UnboundedSender<CapturedMessageWithTime> = {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel(); // TODO bounded?
         std::thread::spawn(|| {
             let rt = tokio::runtime::Builder::new_current_thread()
@@ -55,9 +54,14 @@ lazy_static! {
 
 type NodePtr = usize;
 struct NodeState {
-    address: NodePtr,
-    node_name: String,
-    node_namespace: String,
+    namespace: String,
+    name: String,
+
+    /// This will be used as this node's timeline id. It lets us
+    /// distinguish this node from a similarly named one. These could
+    /// live at the same time, or a node could be destroyed and
+    /// re-created.
+    timeline_id: TimelineId,
 }
 
 /// The unique identifier (gid) of a publisher.
@@ -77,11 +81,11 @@ impl std::fmt::Display for PublisherGraphId {
 
 pub type PublisherPtr = usize;
 struct PublisherState {
-    address: PublisherPtr,
     message_schema: FlatRosMessageSchema,
     topic_name: String,
     node_namespace: String,
     node_name: String,
+    node_timeline_id: TimelineId,
     graph_id: Option<PublisherGraphId>,
 }
 
@@ -95,28 +99,28 @@ pub enum MessageDirection {
     },
 }
 
-type SubscriptionAddress = usize;
+type SubscriptionPtr = usize;
 struct SubscriptionState {
-    address: SubscriptionAddress,
     message_schema: FlatRosMessageSchema,
     topic_name: String,
     node_namespace: String,
     node_name: String,
+    node_timeline_id: TimelineId,
 }
 
 #[derive(Debug)]
-// 'p is the lifetime of the PublisherState entry that these are referring into.
-pub struct CapturedMessage<'p> {
+pub struct CapturedMessage {
     pub kvs: Vec<(String, AttrVal)>,
-    pub topic_name: &'p str,
-    pub node_namespace: &'p str,
-    pub node_name: &'p str,
+    pub topic_name: String,
+    pub node_namespace: String,
+    pub node_name: String,
+    pub node_timeline_id: TimelineId,
     pub direction: MessageDirection,
 }
 
 #[derive(Debug)]
-pub struct CapturedMessageWithTime<'p> {
-    pub msg: CapturedMessage<'p>,
+pub struct CapturedMessageWithTime {
+    pub msg: CapturedMessage,
     pub publish_time: CapturedTime,
     pub receive_time: Option<CapturedTime>,
 }
@@ -159,13 +163,24 @@ redhook::hook! {
         let node_namespace = String::from_utf8_lossy(CStr::from_ptr(namespace).to_bytes()).to_string();
 
         let node_address = redhook::real!(rmw_create_node)(context, name, namespace);
+        let node_timeline_id = TimelineId::allocate();
 
         NODES.rcu(|nodes| {
-            nodes.push_front(NodeState {
-                address: node_address, node_name: node_name.clone(), node_namespace: node_namespace.clone()})
+            nodes.insert(node_address, NodeState {
+                name: node_name.clone(), namespace: node_namespace.clone(), timeline_id: node_timeline_id })
         });
 
         node_address
+    }
+}
+
+redhook::hook! {
+    unsafe fn rmw_destroy_node(node_ptr: NodePtr) -> c_int
+        => modality_hook_rmw_destroy_node
+    {
+        let ret = redhook::real!(rmw_destroy_node)(node_ptr);
+        NODES.rcu(|nodes| nodes.remove(&node_ptr));
+        ret
     }
 }
 
@@ -178,7 +193,7 @@ redhook::hook! {
         let topic_name_str = String::from_utf8_lossy(CStr::from_ptr(topic_name).to_bytes()).to_string();
         let mut maybe_schema = RosMessageSchema::from_c(type_support);
 
-        if let Some(node_state) = NODES.load().iter().find(|ns| ns.address == node) {
+        if let Some(node_state) = NODES.load().get(&node) {
             let publisher_address = redhook::real!(rmw_create_publisher)
                 (node, type_support, topic_name, qos_policies, publisher_options);
 
@@ -189,14 +204,15 @@ redhook::hook! {
             }
 
             if let Some(message_schema) = maybe_schema.take() {
-                PUBLISHERS.rcu(|list| {
-                    list.push_front(
+                PUBLISHERS.rcu(|pubs| {
+                    pubs.insert(
+                        publisher_address,
                         PublisherState {
-                            address: publisher_address,
                             message_schema: message_schema.clone().flatten(&vec![]),
                             topic_name: topic_name_str.clone(),
-                            node_namespace: node_state.node_namespace.clone(),
-                            node_name: node_state.node_name.clone(),
+                            node_namespace: node_state.namespace.clone(),
+                            node_name: node_state.name.clone(),
+                            node_timeline_id: node_state.timeline_id,
                             graph_id
                         }
                     )
@@ -214,24 +230,32 @@ redhook::hook! {
 }
 
 redhook::hook! {
+    unsafe fn rmw_destroy_publisher(node_ptr: NodePtr, pub_ptr: PublisherPtr) -> c_int
+        => modality_hook_rmw_destroy_publisher
+    {
+        let ret = redhook::real!(rmw_destroy_publisher)(node_ptr, pub_ptr);
+        PUBLISHERS.rcu(|pubs| pubs.remove(&pub_ptr));
+        ret
+    }
+}
+
+redhook::hook! {
     unsafe fn rmw_publish(publisher_address: PublisherPtr, message: *const c_void, allocation: *const c_void) -> c_int
         => modality_hook_rmw_publish
     {
-        if let Some(pub_state) = PUBLISHERS.load().iter().find(|ps| ps.address == publisher_address) {
+        if let Some(pub_state) = PUBLISHERS.load().get(&publisher_address) {
             let message_size = pub_state.message_schema.size;
             let src_message_bytes: &[u8] = std::slice::from_raw_parts(message as *const u8, message_size);
             let mut kvs = vec![];
             pub_state.message_schema.interpret_message(None, src_message_bytes, &mut kvs);
 
-            // cast away the lifetime; these are in fact valid for
-            // 'static because the strings are in a global registry,
-            // which is a grow-only persistent data structure..
-            let topic_name: &'static str = &*(pub_state.topic_name.as_str() as *const _);
-            let node_namespace: &'static str = &*(pub_state.node_namespace.as_str() as *const _);
-            let node_name: &'static str = &*(pub_state.node_name.as_str() as *const _);
-            // TODO ref here
+            let topic_name = pub_state.topic_name.clone();
+            let node_namespace = pub_state.node_namespace.clone();
+            let node_name = pub_state.node_name.clone();
+            let node_timeline_id = pub_state.node_timeline_id;
+
             let direction = MessageDirection::Send { local_publisher_graph_id: pub_state.graph_id };
-            let captured_message = CapturedMessage { kvs, topic_name, node_namespace, node_name, direction };
+            let captured_message = CapturedMessage { kvs, topic_name, node_namespace, node_name, direction, node_timeline_id };
             let _called_after_dest = LAST_CAPTURED_MESSAGE.try_with(|lcm| {
                 *lcm.borrow_mut() = Some(captured_message);
             }).is_err();
@@ -282,26 +306,27 @@ redhook::hook! {
 redhook::hook! {
     unsafe fn rmw_create_subscription(node: NodePtr, type_support: *const interop::RosIdlMessageTypeSupportT,
                                       topic_name: *const c_char, qos_policies: *const c_void,
-                                      subscription_options: *const c_void) -> SubscriptionAddress
+                                      subscription_options: *const c_void) -> SubscriptionPtr
         => modality_hook_rmw_create_subscription
 
     {
         let topic_name_str = String::from_utf8_lossy(CStr::from_ptr(topic_name).to_bytes()).to_string();
         let mut maybe_schema = RosMessageSchema::from_c(type_support);
 
-        if let Some(node_state) = NODES.load().iter().find(|ns| ns.address == node) {
+        if let Some(node_state) = NODES.load().get(&node) {
             let subscription_address = redhook::real!(rmw_create_subscription)
                 (node, type_support, topic_name, qos_policies, subscription_options);
 
             if let Some(message_schema) = maybe_schema.take() {
-                SUBSCRIPTIONS.rcu(|list| {
-                    list.push_front(
+                SUBSCRIPTIONS.rcu(|subs| {
+                    subs.insert(
+                        subscription_address,
                         SubscriptionState {
-                            address: subscription_address,
                             message_schema: message_schema.clone().flatten(&vec![]),
                             topic_name: topic_name_str.clone(),
-                            node_namespace: node_state.node_namespace.clone(),
-                            node_name: node_state.node_name.clone(),
+                            node_namespace: node_state.namespace.clone(),
+                            node_name: node_state.name.clone(),
+                            node_timeline_id: node_state.timeline_id,
                         }
                     )
                 });
@@ -315,6 +340,16 @@ redhook::hook! {
 }
 
 redhook::hook! {
+    unsafe fn rmw_destroy_subscription(node_ptr: NodePtr, sub_ptr: SubscriptionPtr) -> c_int
+        => modality_hook_rmw_destroy_subscription
+    {
+        let ret = redhook::real!(rmw_destroy_subscription)(node_ptr, sub_ptr);
+        SUBSCRIPTIONS.rcu(|subs| subs.remove(&sub_ptr));
+        ret
+    }
+}
+
+redhook::hook! {
     unsafe fn rmw_take_with_info(subscription_address: PublisherPtr,
                                  message: *mut c_void, taken: *mut bool, message_info: *mut RmwMessageInfo,
                                  allocation: *mut c_void) -> c_int
@@ -324,7 +359,7 @@ redhook::hook! {
         let res = redhook::real!(rmw_take_with_info)(subscription_address, message, taken, message_info, allocation);
         // 0 is success
         if res == 0 {
-            if let Some(sub_state) = SUBSCRIPTIONS.load().iter().find(|sub| sub.address == subscription_address) {
+            if let Some(sub_state) = SUBSCRIPTIONS.load().get(&subscription_address) {
                 let message_size = sub_state.message_schema.size;
                 let src_message_bytes: &[u8] = std::slice::from_raw_parts(message as *const u8, message_size);
                 let mut kvs = vec![];
@@ -333,15 +368,16 @@ redhook::hook! {
                 // cast away the lifetime; these are in fact valid for
                 // 'static because the strings are in a global registry,
                 // which is a grow-only persistent data structure.
-                let topic_name: &'static str = &*(sub_state.topic_name.as_str() as *const _);
-                let node_namespace: &'static str = &*(sub_state.node_namespace.as_str() as *const _);
-                let node_name: &'static str = &*(sub_state.node_name.as_str() as *const _);
+                let topic_name = sub_state.topic_name.clone();
+                let node_namespace = sub_state.node_namespace.clone();
+                let node_name = sub_state.node_name.clone();
+                let node_timeline_id = sub_state.node_timeline_id;
 
                 let remote_publisher_graph_id = Some(PublisherGraphId((*message_info).publisher_gid.data));
                 let direction = MessageDirection::Receive { remote_publisher_graph_id };
 
                 let msg = CapturedMessageWithTime {
-                    msg: CapturedMessage { kvs, topic_name, node_namespace, node_name, direction},
+                    msg: CapturedMessage { kvs, topic_name, node_namespace, node_name, direction, node_timeline_id },
                     publish_time: CapturedTime::SignedEpochNanos((*message_info).source_timestamp),
                     receive_time: Some(CapturedTime::SignedEpochNanos((*message_info).received_timestamp)),
                 };

--- a/modality-ros-hook/src/hooks.rs
+++ b/modality-ros-hook/src/hooks.rs
@@ -481,8 +481,12 @@ redhook::hook! {
 
         let res = redhook::real!(clock_gettime)(clock_id, timespec);
 
-        // 0 means success
-        if res == 0 {
+        // return value 0 means success
+        //
+        // clock id 0 is the regular wall clock. fastdds does some
+        // other calls for a different id before this one, which is
+        // attached to the message.
+        if res == 0 && clock_id == 0 {
             let _called_after_dest = LAST_CAPTURED_MESSAGE.try_with(|b| {
                 if let Some(msgs) = b.borrow_mut().take() {
                     for msg in msgs.into_iter() {

--- a/modality-ros-hook/src/lib.rs
+++ b/modality-ros-hook/src/lib.rs
@@ -304,7 +304,6 @@ impl FlatRosMessageSchema {
             self.interpret_message_internal(None, message, &mut kvs);
 
             if let Some(msg) = extract_log_message(self, &kvs) {
-                println!("---> {msg}");
                 kvs.push(("name".to_string(), msg));
             }
 
@@ -455,14 +454,8 @@ fn extract_log_message(
     schema: &FlatRosMessageSchema,
     kvs: &[(String, AttrVal)],
 ) -> Option<AttrVal> {
-    println!(
-        "--> extract_log_message {} {}",
-        schema.namespace, schema.name
-    );
     if schema.namespace == "rcl_interfaces__msg" && schema.name == "Log" {
-        println!("--> match! kvs: {kvs:?}");
         if let Some((_, msg)) = kvs.iter().find(|(k, _)| k == "msg") {
-            println!("--> Found msg {msg}");
             return Some(msg.clone());
         }
     }

--- a/modality-ros-hook/src/lib.rs
+++ b/modality-ros-hook/src/lib.rs
@@ -368,7 +368,6 @@ impl FlatRosMessageSchema {
                                 local_attr_kvs.iter().find(|t| t.0 == "key"),
                                 local_attr_kvs.iter().find(|t| t.0 == "value"),
                             ) {
-                                // TODO more complete key normalization
                                 let ks = normalize_string_for_attr_key(k.to_string());
                                 kvs.push((ks.clone(), v.clone()));
                                 kvs.push((format!("{ks}.key"), AttrVal::String(k.to_string())));
@@ -443,7 +442,7 @@ fn as_values_field(member: &FlatRosMessageMemberSchema) -> Option<&MessageSequen
                     },
                 ..
             },
-        ) if key == "values" && namespace == "diagnostic_msgs::msg" && name == "KeyValue" => {
+        ) if key == "values" && (namespace == "diagnostic_msgs::msg" || namespace == "diagnostic_msgs__msg") && name == "KeyValue" => {
             Some(seq)
         }
         _ => None,
@@ -454,7 +453,7 @@ fn extract_log_message(
     schema: &FlatRosMessageSchema,
     kvs: &[(String, AttrVal)],
 ) -> Option<AttrVal> {
-    if schema.namespace == "rcl_interfaces__msg" && schema.name == "Log" {
+    if (schema.namespace == "rcl_interfaces__msg" || schema.namespace == "rcl_interfaces::msg") && schema.name == "Log" {
         if let Some((_, msg)) = kvs.iter().find(|(k, _)| k == "msg") {
             return Some(msg.clone());
         }


### PR DESCRIPTION
- Track 'destroy' for Node, Subscription, and Publisher
- Censor the '/parameter_events' topic
- Special handling for the 'diagnostics' channel
- Use the 'msg' field from known Log messages as the event name
